### PR TITLE
Extending Wait Utils

### DIFF
--- a/src/oadp_utils/wait.py
+++ b/src/oadp_utils/wait.py
@@ -3,7 +3,6 @@ import time
 from datetime import datetime
 from datetime import timedelta
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/oadp_utils/wait.py
+++ b/src/oadp_utils/wait.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 logger = logging.getLogger(__name__)
 
 
-def wait_for(condition_function, description="Something", wait_timeout=200, sleep=5):
+def wait_for(condition_function, description="Something", wait_timeout=200, sleep=5, **func_kwargs):
     """
     Providing a way to wait for any function to return true.
 
@@ -22,10 +22,10 @@ def wait_for(condition_function, description="Something", wait_timeout=200, slee
     """
     logger.info(f"Waiting For {description}, any status information should be logged by your condition_function! ")
     timeout = datetime.now() + timedelta(seconds=wait_timeout)
-    while datetime.now() < timeout and not condition_function():
+    while datetime.now() < timeout and not condition_function(**func_kwargs):
         time.sleep(sleep)
 
-    if not condition_function():
+    if not condition_function(**func_kwargs):
         logger.info(f"Waiting For {description}-TIMEOUT")
         raise TimeoutError
     logger.info(f"Waiting For {description}-OK")

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,21 +1,23 @@
+import logging
 import unittest
 
 from src.oadp_utils.wait import wait_for
 
+logger = print
 
-def func(**kwargs):
-    print(kwargs)
+
+def func1(**kwargs):
+    logger(kwargs)
     return True
 
 
 class TestWait(unittest.TestCase):
 
     def test_wait(self):
-        result = wait_for(condition_function=func, description="חכה לי פינוקיו", wait_timeout=200, sleep=5, x=1, y=2)
+        result = wait_for(condition_function=func1, description="חכה לי פינוקיו", wait_timeout=200, sleep=5, x=1, y=2)
 
         self.assertEqual(result, True)
 
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,0 +1,21 @@
+import unittest
+
+from src.oadp_utils.wait import wait_for
+
+
+def func(**kwargs):
+    print(kwargs)
+    return True
+
+
+class TestWait(unittest.TestCase):
+
+    def test_wait(self):
+        result = wait_for(condition_function=func, description="חכה לי פינוקיו", wait_timeout=200, sleep=5, x=1, y=2)
+
+        self.assertEqual(result, True)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Extending wait_for with **fun_kwargs so it can be used in the  call_function.
Not: The calling function must have **kwargs as the last argument
