### PR TITLE
Extend wait to handle break

### DIFF
--- a/src/oadp_utils/wait.py
+++ b/src/oadp_utils/wait.py
@@ -6,9 +6,15 @@ from datetime import timedelta
 logger = logging.getLogger(__name__)
 
 
+class ExitConditionFoundError(Exception):
+    pass
+
+
 def wait_for(condition_function, description="Something", wait_timeout=200, sleep=5, **func_kwargs):
     """
     Providing a way to wait for any function to return true.
+    If the function should return a tuple,
+    the second item is considered a break criteria and ExitConditionFoundError is raised.
 
     Example: wait_for(condition_function=dpa.reconciled, description="Wait For Data Protection Application
     Resource.", timeout=200, sleep=5):
@@ -21,11 +27,24 @@ def wait_for(condition_function, description="Something", wait_timeout=200, slee
     """
     logger.info(f"Waiting For {description}, any status information should be logged by your condition_function! ")
     timeout = datetime.now() + timedelta(seconds=wait_timeout)
-    while datetime.now() < timeout and not condition_function(**func_kwargs):
+    condition_met = False
+    exit_condition_found = False
+    while datetime.now() < timeout and not condition_met \
+            and not exit_condition_found:
+        conditions = condition_function(**func_kwargs)
+        if type(conditions) == tuple:
+            condition_met = conditions[0]
+            exit_condition_found = conditions[1]
+        else:
+            condition_met = conditions
         time.sleep(sleep)
 
-    if not condition_function(**func_kwargs):
-        logger.info(f"Waiting For {description}-TIMEOUT")
-        raise TimeoutError
-    logger.info(f"Waiting For {description}-OK")
-    return True
+    if exit_condition_found:
+        logger.warning("Waiting For {description}-BRAKE")
+        raise ExitConditionFoundError
+
+    if condition_met:
+        logger.info(f"Waiting For {description}-OK")
+
+    return condition_met
+

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,22 +1,52 @@
-import logging
 import unittest
 
-from src.oadp_utils.wait import wait_for
+import pytest
+
+from src.oadp_utils.wait import wait_for, ExitConditionFoundError
 
 logger = print
 
 
-def func1(**kwargs):
+def f_condition_met(**kwargs):
     logger(kwargs)
     return True
 
 
+def f_exit_condition_found(**kwargs):
+    logger(kwargs)
+    return False, True
+
+
+def f_time_out(**kwargs):
+    logger(kwargs)
+    return False, False
+
+
 class TestWait(unittest.TestCase):
 
-    def test_wait(self):
-        result = wait_for(condition_function=func1, description="חכה לי פינוקיו", wait_timeout=200, sleep=5, x=1, y=2)
+    def test_wait_condition_found(self):
+        assert wait_for(condition_function=f_condition_met,
+                        description="Some Condition.",
+                        wait_timeout=10, sleep=1, x=1, y=2)
 
-        self.assertEqual(result, True)
+    def test_wait_timeout(self):
+
+        try:
+            wait_for(condition_function=f_condition_met,
+                     description="Some Condition.and expect it to Timeout",
+                     wait_timeout=10, sleep=1, x=1, y=2)
+        except TimeoutError:
+            pass
+        pytest.xfail("TimeoutError was not raised.")
+
+    def test_wait_exit_condition_found(self):
+        try:
+            wait_for(condition_function=f_exit_condition_found,
+                     description="Exit Condition and expect ExitConditionFoundError",
+                     wait_timeout=200, sleep=5, x=1, y=2)
+
+        except ExitConditionFoundError:
+            pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding the ability to break by allowing the condition function return a tuple of 2 bools:
1st one has before
2nd If True, the wait loops breaks
To Allow brake conditions, sunc ah falied , so it will not wait for  condition that never comes. 